### PR TITLE
Fix compilation error for kernels < 6.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ KERNEL_DIR  = /lib/modules/$(KVERSION)/build
 MODULE_DIR  = /lib/modules/$(KVERSION)
 
 ifneq ($(DKMS),)
-MODULE_INSTALLED := $(shell dkms status $(MODULE_NAME))
+MODULE_INSTALLED := $(shell dkms status $(MODULE_NAME) -k $(KVERSION))
 else
 MODULE_INSTALLED =
 endif
@@ -43,11 +43,11 @@ ifneq ($(MODULE_INSTALLED),)
 	@echo Module $(MODULE_NAME) is installed ... uninstall it first
 	@make uninstall
 endif
-	@dkms install .
+	@dkms install . -k $(KVERSION)
 	
 uninstall:
 ifneq ($(MODULE_INSTALLED),)
-	dkms remove -m $(MODULE_NAME) -v $(MODULE_VERSION) --all
+	dkms remove -m $(MODULE_NAME) -v $(MODULE_VERSION) -k $(KVERSION) --all
 	rm -rf /usr/src/$(MODULE_NAME)-$(MODULE_VERSION)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 	
 uninstall:
 ifneq ($(MODULE_INSTALLED),)
-	dkms remove -m $(MODULE_NAME) -v $(MODULE_VERSION) -k $(KVERSION) --all
+	dkms remove -m $(MODULE_NAME) -v $(MODULE_VERSION) --all
 	rm -rf /usr/src/$(MODULE_NAME)-$(MODULE_VERSION)
 endif
 

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -47,7 +47,11 @@
 #include <linux/slab.h>
 #include <linux/usb.h>
 #include <linux/spi/spi.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
+#include <linux/gpio.h>
+#else
 #include <linux/gpio/driver.h>
+#endif
 #include <linux/irq.h>
 
 /** 


### PR DESCRIPTION
Hi @dimich-dmb,

First of all, thank you for maintaining this driver, it really helped me for one of my projects.

I just wanted to inform you that the commit a54b1a3c1479238bf6a51e5aa67277a5406e17f2, which changes `<linux/gpio.h>` by `<linux/gpio/driver.h>`, broke the compilation of the driver on kernels < 6.4.

It was also reported in the issue #4, if I'm not mistaken.

To solve the issue, I just added a preprocessor condition so that it uses `<linux/gpio.h>` instead of `<linux/gpio/driver.h>` on kernels < 6.4.

I also fixed an installation error when using DKMS.

Have a nice day 🙂